### PR TITLE
use curl --http1.1

### DIFF
--- a/cm3-installer-data/bin/run-cm3-install
+++ b/cm3-installer-data/bin/run-cm3-install
@@ -7,6 +7,6 @@ echo "Checking for disks..."
 sleep 10
 ls -l /dev/sd*
 echo "starting image download..."
-curl -Lf $1 |unxz -c |dd of=/dev/sda bs=4M oflag=sync
+curl --http1.1 -Lf $1 |unxz -c |dd of=/dev/sda bs=4M oflag=sync
 sync
 partprobe /dev/sda

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,10 +1,10 @@
 name: cm3-installer
-version: '0.1'
+version: '0.2'
 summary: Automated installation of cm3 in a specific lab environment
 description: |
   You probably don't want this
 
-base: core18
+base: core20
 grade: devel
 confinement: devmode
 
@@ -14,36 +14,27 @@ architectures:
   - build-on: armhf
 
 apps:
-  python:
-    command: python3
   rpiboot:
-    command: rpiboot -d $SNAP/msd
+    command: usr/bin/rpiboot -d $SNAP/msd
     plugs: [raw-usb, network-control]
   cm3-installer:
     command: bin/run-cm3-install
 
 parts:
-  automationhat:
-    plugin: python
-    python-packages:
-      - automationhat
-      - smbus-cffi
-    build-packages:
-      - python3-dev
-      - libffi-dev
-
   rpiboot:
     plugin: make
     source: https://github.com/raspberrypi/usbboot.git
-    override-prime: |
-      snapcraftctl prime
-      cp $SNAPCRAFT_PART_BUILD/rpiboot $SNAPCRAFT_PRIME/usr/bin/
-      cp -a $SNAPCRAFT_PART_BUILD/msd $SNAPCRAFT_PRIME
     build-packages:
       - pkg-config
       - libusb-1.0-0-dev
     stage-packages:
       - libusb-1.0-0
+    override-build: |
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin
+      mkdir -p $SNAPCRAFT_PART_INSTALL/msd
+      cp rpiboot $SNAPCRAFT_PART_INSTALL/usr/bin/
+      cp -a msd/* $SNAPCRAFT_PART_INSTALL/msd/
 
   stuff:
     plugin: dump


### PR DESCRIPTION
Hey Paul! I hope you're doing well :)

We are seeing `curl: (16) Error in the HTTP2 framing layer` while feeding the HTTPS URL to cm3-installer.
After investigation, I found it can be addressed by using `curl --http1.1`. 

This PR also includes some changes to fix the issue when building in the Snap store.
- use `core20` to allow snapcraft 7.x/stable installation in launchpad-build
- replace steps in override-prime with override-build to fix `SNAPCRAFT_PART_BUILD: unbound variable` in core20
- remove automationhat and python to avoid the error.  Both of them seem not used, so I'd assume it's fine to remove them? 
```
ERROR: Could not find a version that satisfies the requirement gpiod>=2.1.3 (from automationhat) (from versions: 0.2.0,  0.3.0, 0.4.0, 0.4.1, 0.5.0, 0.5.1, 0.5.2, 0.5.3, 0.5.4, 0.6.0, 1.0.0, 1.0.1, 1.1.0, 1.1.2, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, 1.3.0, 1.4.0, 1.5.0, 1.5.1, 1.5.2, 1.5.3, 1.5.4)
```


I was able to build a snap `cm3-installer-new` with the changes. And then I thought it should be better to merge it back to the upstream and keep using `cm3-installer`. What do you think?